### PR TITLE
Fixed meal name extraction from the HTML element.

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -14,10 +14,9 @@
   const hosting = "https://bsacharski.github.io/startedu-meals";
   const imageData = "https://bsacharski.github.io/startedu-meals";
 
-
   const init = () => {
-      addSourceJson();
-      addPreviewNode();
+    addSourceJson();
+    addPreviewNode();
   };
 
   const addSourceJson = () => {
@@ -30,8 +29,6 @@
     scriptElement.addEventListener("load", () => {
       window.setInterval(processMeals, intervalTimeout);
     });
-
-
   };
 
   const addPreviewNode = () => {
@@ -57,8 +54,10 @@
         return;
       }
 
-      const mealName = parentElement.innerText.toLowerCase();
-      appendImageToNode(allergenInfo, mealName);
+      if (parentElement.childNodes.length) {
+        const mealName = parentElement.childNodes[0].textContent.toLowerCase();
+        appendImageToNode(allergenInfo, mealName);
+      }
     });
   };
 
@@ -92,6 +91,5 @@
     });
   };
 
-  init()
-
+  init();
 })();

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "StartEdu - WebExtension",
-  "version": "0.66",
+  "version": "0.67",
   "icons": {
     "48": "assets/icons/apple-icon-57x57.png",
     "96": "assets/icons/favicon-96x96.png"
@@ -9,11 +9,9 @@
   "permissions": ["activeTab"],
   "content_scripts": [
     {
-      "matches": [
-        "*://startedu.pl/*"
-      ],
-      "js": [ "assets/js/background.js" ],
-      "css": [ "assets/css/index.css" ],
+      "matches": ["*://startedu.pl/*"],
+      "js": ["assets/js/background.js"],
+      "css": ["assets/css/index.css"],
       "run_at": "document_end",
       "persistent": true
     }
@@ -22,7 +20,5 @@
     "scripts": ["assets/js/index.js"],
     "persistent": true
   },
-  "web_accessible_resources": [
-    "assets/js/index.js"
-  ]
+  "web_accessible_resources": ["assets/js/index.js"]
 }


### PR DESCRIPTION
StartEdu has introduced a breaking change in the HTML structure
of the meal.

The service now add ingredients information the the `.meal-preview` node.
```html
<li>
  NUGGETSY Z KURCZAKA, DIP ŚMIETANOWO-CZOSNKOWY, ZIEMNIAKI OPIEKANE, COLESLAW
  <div class="no-print">
    <i class="small"
      >Skład: 380 gr, biała kapusta, marchew, majonez, jogurt naturalny</i
    >
  </div>
  <div class="allergen-info" preview-status="true">
    <div class="mark-1" title="Zawiera gluten"></div>
    <div class="mark-3" title="Zawiera jajka"></div>
    <div class="mark-7" title="Zawiera mleko / nabiał"></div>
    <img
      class="meal-preview"
      src="https://bsacharski.github.io/startedu-meals/images/IMG_5121_thumb.JPG"
    />
  </div>
</li>
```

As such, the `innerText` property of the node would also return the text with
ingredients information.

The logic was fixed, to pull the information from the first childNode of the
HTML element, which contains only pure text-information about the meal-name.